### PR TITLE
Add iCEBreaker board example

### DIFF
--- a/boards/icebreaker/Makefile
+++ b/boards/icebreaker/Makefile
@@ -1,0 +1,26 @@
+TARGET=usb_hid_host_demo
+TOP=usb_hid_host_demo
+
+COM=../common
+SRC=../../src
+
+OBJS+=top.v clock.v $(COM)/hid_printer.v $(COM)/uart_tx_V2.v $(SRC)/usb_hid_host.v $(SRC)/usb_hid_host_rom.v
+
+all: ${TARGET}.bin
+
+$(TARGET).json: $(OBJS)
+	yosys build.ys
+
+$(TARGET).asc: $(TARGET).json
+	nextpnr-ice40 --up5k --package sg48 --json $< --asc $@ --pcf $(TARGET).pcf --freq 24
+
+$(TARGET).bin: $(TARGET).asc
+	icepack $< $@
+
+prog:
+	iceprog $(TARGET).bin
+
+clean:
+	rm -f *.bin *.config *.asc *.json
+
+.PHONY: prog clean

--- a/boards/icebreaker/Makefile
+++ b/boards/icebreaker/Makefile
@@ -4,7 +4,7 @@ TOP=usb_hid_host_demo
 COM=../common
 SRC=../../src
 
-OBJS+=top.v clock.v $(COM)/hid_printer.v $(COM)/uart_tx_V2.v $(SRC)/usb_hid_host.v $(SRC)/usb_hid_host_rom.v
+OBJS+=top.v $(COM)/hid_printer.v $(COM)/uart_tx_V2.v $(SRC)/usb_hid_host.v $(SRC)/usb_hid_host_rom.v
 
 all: ${TARGET}.bin
 

--- a/boards/icebreaker/build.ys
+++ b/boards/icebreaker/build.ys
@@ -1,0 +1,12 @@
+
+verilog_defaults -add -I../common -I../../src
+
+read_verilog top.v
+read_verilog clock.v
+read_verilog ../common/hid_printer.v
+read_verilog ../common/uart_tx_V2.v
+read_verilog ../../src/usb_hid_host.v
+read_verilog ../../src/usb_hid_host_rom.v
+
+synth_ice40 -top top -json usb_hid_host_demo.json
+

--- a/boards/icebreaker/build.ys
+++ b/boards/icebreaker/build.ys
@@ -2,7 +2,6 @@
 verilog_defaults -add -I../common -I../../src
 
 read_verilog top.v
-read_verilog clock.v
 read_verilog ../common/hid_printer.v
 read_verilog ../common/uart_tx_V2.v
 read_verilog ../../src/usb_hid_host.v

--- a/boards/icebreaker/top.v
+++ b/boards/icebreaker/top.v
@@ -1,0 +1,62 @@
+//
+// Example using the usb_hid_host core, for Machdyne Riegel
+// based on the icesugar-pro example by nand2mario, 8/2023
+//
+
+module top (
+    input sys_clk,
+    input sys_resetn,
+    // input s1,
+
+    // UART
+    input UART_RXD,
+    output UART_TXD,
+
+    // LEDs
+    output led,
+
+    // USB
+    inout usbdm,
+    inout usbdp
+);
+
+wire [1:0] usb_type;
+wire [7:0] key_modifiers, key1, key2, key3, key4;
+wire [7:0] mouse_btn;
+wire signed [7:0] mouse_dx, mouse_dy;
+wire [63:0] hid_report;
+wire usb_report, usb_conerr, game_l, game_r, game_u, game_d, game_a, game_b, game_x, game_y;
+wire game_sel, game_sta;
+wire [13:0] dbg_pc;
+wire [3:0] dbg_inst;
+
+usb_hid_host usb (
+    .usbclk(sys_clk), .usbrst_n(sys_resetn),
+    .usb_dm(usbdm), .usb_dp(usbdp),	
+    .typ(usb_type), .report(usb_report),
+    .key_modifiers(key_modifiers), .key1(key1), .key2(key2), .key3(key3), .key4(key4),
+    .mouse_btn(mouse_btn), .mouse_dx(mouse_dx), .mouse_dy(mouse_dy),
+    .game_l(game_l), .game_r(game_r), .game_u(game_u), .game_d(game_d),
+    .game_a(game_a), .game_b(game_b), .game_x(game_x), .game_y(game_y), 
+    .game_sel(game_sel), .game_sta(game_sta),
+    .conerr(usb_conerr), .dbg_hid_report(hid_report)
+);
+
+hid_printer prt (
+    .clk(sys_clk), .resetn(sys_resetn),
+    .uart_tx(UART_TXD), .usb_type(usb_type), .usb_report(usb_report),
+    .key_modifiers(key_modifiers), .key1(key1), .key2(key2), .key3(key3), .key4(key4),
+    .mouse_btn(mouse_btn), .mouse_dx(mouse_dx), .mouse_dy(mouse_dy),
+    .game_l(game_l), .game_r(game_r), .game_u(game_u), .game_d(game_d),
+    .game_a(game_a), .game_b(game_b), .game_x(game_x), .game_y(game_y), 
+    .game_sel(game_sel), .game_sta(game_sta)
+);
+
+reg report_toggle;      // blinks whenever there's a report
+always @(posedge sys_clk) if (usb_report) report_toggle <= ~report_toggle;
+
+assign led = report_toggle;
+//assign leds[7:0] = ~{6'b0, usb_type};
+//assign leds[15:8] = ~8'b0;
+
+endmodule

--- a/boards/icebreaker/top.v
+++ b/boards/icebreaker/top.v
@@ -1,6 +1,6 @@
 //
-// Example using the usb_hid_host core, for Machdyne Riegel
-// based on the icesugar-pro example by nand2mario, 8/2023
+// Example using the usb_hid_host core, for iCEBreaker board
+// based on the icesugar-pro example by nand2mario, 9/2023
 //
 
 module top (

--- a/boards/icebreaker/usb_hid_host_demo.pcf
+++ b/boards/icebreaker/usb_hid_host_demo.pcf
@@ -1,0 +1,16 @@
+# 12 MHz clock
+set_io -nowarn sys_clk        35
+set_frequency sys_clk 12
+
+set_io sys_resetn 10
+set_io led 11
+
+set_io -nowarn UART_RXD          6
+set_io -nowarn UART_TXD          9
+
+
+# usb_host_dual_socket_pmod on PMOD1B
+set_io usbdp 31
+set_io usbdm 28
+
+


### PR DESCRIPTION
Main adaptation changes:
- Removed clock/pll from project as the iCEBreaker has a 12MHz default clock already
- Selected the correct device (up5k) and package (sg48) in Makefile
- Changed pins in .pcf to match the device

